### PR TITLE
Update base.html for Django 3

### DIFF
--- a/asutheme/templates/asutheme/base.html
+++ b/asutheme/templates/asutheme/base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <!doctype html>
 <html class="no=js" {% block html_attrs %}{% endblock %}>
 <head>


### PR DESCRIPTION
Minor change necessary for compatibility with Django 3 onwards, from staticfiles is now implied and the template will not load if it is specified.